### PR TITLE
Fix failing build on Ubuntu with clang

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,17 +29,17 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04, windows-latest ]
         build_type: [ Release ]
         c_compiler: [ gcc, clang, cl ]
         include:
           - os: windows-latest
             c_compiler: cl
             cpp_compiler: cl
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             c_compiler: gcc
             cpp_compiler: g++
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             c_compiler: clang
             cpp_compiler: clang++
         exclude:
@@ -47,7 +47,7 @@ jobs:
             c_compiler: gcc
           - os: windows-latest
             c_compiler: clang
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             c_compiler: cl
 
     steps:
@@ -55,13 +55,13 @@ jobs:
 
       - name: 🔧 Install GCC
         uses: egor-tensin/setup-gcc@v1.3
-        if: matrix.os == 'ubuntu-latest' && matrix.c_compiler == 'gcc'
+        if: matrix.os == 'ubuntu-24.04' && matrix.c_compiler == 'gcc'
         with:
           version: 13
 
       - name: 🔧 Install Clang
         uses: egor-tensin/setup-clang@v1.4
-        if: matrix.os == 'ubuntu-latest' && matrix.c_compiler == 'clang'
+        if: matrix.os == 'ubuntu-24.04' && matrix.c_compiler == 'clang'
         with:
           version: 16
 


### PR DESCRIPTION
For some strange reason libstc++ obviously changed over the last months so that it doesn't include the formatting library anymore. Updating the runners to 24.04, they now provide libstc++ in version 13 that in turn supports this feature.